### PR TITLE
Checkout tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,19 +189,17 @@ function checkBranch(submodule) {
   const gitOptions = { cwd: submodule.repo }
   return exec_git('symbolic-ref --short -q HEAD', gitOptions)
     .then(currentBranch => {
-      if (currentBranch !== submodule.branch) {
-        submodule.log(`Switching branches from ${currentBranch} to ${submodule.branch}`, 2);
-        return exec_git(`branch --list -q --no-color ${submodule.branch}`, gitOptions)
-          .then(existingTargetBranch => {
-            if (existingTargetBranch !== submodule.branch) {
-              return checkoutAndTrackNewBranch(submodule);
-            } else {
-              return checkoutBranch(submodule);
-            }
-          });
-        } else {
-          return null;
-        }
+      if (currentBranch === submodule.branch)
+        return null;
+      submodule.log(`Switching branches from ${currentBranch} to ${submodule.branch}`, 2);
+      return exec_git(`branch --list -q --no-color ${submodule.branch}`, gitOptions)
+        .then(existingTargetBranch => {
+          if (existingTargetBranch !== submodule.branch) {
+            return checkoutAndTrackNewBranch(submodule);
+          } else {
+            return checkoutBranch(submodule);
+          }
+        })
       });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,10 @@ function checkBranch(submodule) {
       submodule.log(`Switching branches from ${currentBranch} to ${submodule.branch}`, 2);
       return exec_git(`branch --list -q --no-color ${submodule.branch}`, gitOptions)
         .then(existingTargetBranch => checkoutBranch(submodule, existingTargetBranch === submodule.branch))
-      });
+        .catch(err => fetchTags(submodule)
+          .then(() => checkoutBranch(submodule))
+          .catch(() => submodule.log(err)))
+    });
 }
 
 function checkoutBranch(submodule, isNewBranch) {
@@ -204,6 +207,8 @@ function checkoutBranch(submodule, isNewBranch) {
   return exec_git(command, { cwd: submodule.repo });
 }
 
+function fetchTags(submodule) {
+  return exec_git(`fetch --tags`, { cwd: submodule.repo })
 }
 
 function pull(submodule) {

--- a/src/index.js
+++ b/src/index.js
@@ -193,22 +193,17 @@ function checkBranch(submodule) {
         return null;
       submodule.log(`Switching branches from ${currentBranch} to ${submodule.branch}`, 2);
       return exec_git(`branch --list -q --no-color ${submodule.branch}`, gitOptions)
-        .then(existingTargetBranch => {
-          if (existingTargetBranch !== submodule.branch) {
-            return checkoutAndTrackNewBranch(submodule);
-          } else {
-            return checkoutBranch(submodule);
-          }
-        })
+        .then(existingTargetBranch => checkoutBranch(submodule, existingTargetBranch === submodule.branch))
       });
 }
 
-function checkoutAndTrackNewBranch(submodule) {
-  return exec_git(`checkout -B ${submodule.branch} --track origin/${submodule.branch}`, { cwd: submodule.repo });
+function checkoutBranch(submodule, isNewBranch) {
+  const command = isNewBranch
+    ? `checkout -B ${submodule.branch} --track origin/${submodule.branch}`
+    : `checkout ${submodule.branch}`
+  return exec_git(command, { cwd: submodule.repo });
 }
 
-function checkoutBranch(submodule) {
-  return exec_git(`checkout ${submodule.branch}`, { cwd: submodule.repo });
 }
 
 function pull(submodule) {

--- a/src/index.js
+++ b/src/index.js
@@ -186,22 +186,31 @@ function fetchOrigin(submodule) {
 }
 
 function checkBranch(submodule) {
-  return exec_git('symbolic-ref --short -q HEAD', { cwd: submodule.repo })
+  const gitOptions = { cwd: submodule.repo }
+  return exec_git('symbolic-ref --short -q HEAD', gitOptions)
     .then(currentBranch => {
       if (currentBranch !== submodule.branch) {
         submodule.log(`Switching branches from ${currentBranch} to ${submodule.branch}`, 2);
-        return exec_git(`branch --list -q --no-color ${submodule.branch}`, { cwd: submodule.repo })
+        return exec_git(`branch --list -q --no-color ${submodule.branch}`, gitOptions)
           .then(existingTargetBranch => {
             if (existingTargetBranch !== submodule.branch) {
-              return exec_git(`checkout -B ${submodule.branch} --track origin/${submodule.branch}`, { cwd: submodule.repo });
+              return checkoutAndTrackNewBranch(submodule);
             } else {
-              return exec_git(`checkout ${submodule.branch}`, { cwd: submodule.repo });
+              return checkoutBranch(submodule);
             }
           });
         } else {
           return null;
         }
       });
+}
+
+function checkoutAndTrackNewBranch(submodule) {
+  return exec_git(`checkout -B ${submodule.branch} --track origin/${submodule.branch}`, { cwd: submodule.repo });
+}
+
+function checkoutBranch(submodule) {
+  return exec_git(`checkout ${submodule.branch}`, { cwd: submodule.repo });
 }
 
 function pull(submodule) {


### PR DESCRIPTION
In the case that checking out a branch doesn't work, this will fetch the tags and attempt to check out that tag.

This leaves the repository on a detached HEAD at the point of the tag.  I can't decide if that's the appropriate behavior.  We could create a new branch with the tag name locally and try to avoid the detached HEAD instead, but I don't really have a concern except for the mildly concerning horror that the name "detached HEAD" brings to mind.  We probably don't want to create lots of branches for the developer to maintain, but I also don't want devs to find themselves in some sort of git Hell over it.